### PR TITLE
Capitalise table names

### DIFF
--- a/resource_server/src/main/java/com/train/resource_server/entity/Choice.java
+++ b/resource_server/src/main/java/com/train/resource_server/entity/Choice.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 
 
 @Entity
-@Table(name = "choice")
+@Table(name = "Choice")
 public class Choice {
 
     @Id

--- a/resource_server/src/main/java/com/train/resource_server/entity/QuestionChoice.java
+++ b/resource_server/src/main/java/com/train/resource_server/entity/QuestionChoice.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 
 @Entity
 @IdClass(QuestionChoiceId.class) // Composite primary key class (see below)
-@Table(name = "questionchoice")
+@Table(name = "QuestionChoice")
 public class QuestionChoice {
 
     @Id

--- a/resource_server/src/main/java/com/train/resource_server/entity/Users.java
+++ b/resource_server/src/main/java/com/train/resource_server/entity/Users.java
@@ -3,7 +3,7 @@ import jakarta.persistence.*;
 
 
 @Entity
-@Table(name = "users")
+@Table(name = "Users")
 public class Users {
 
     @Id


### PR DESCRIPTION
Just had to make sure the table names matched the ones on the database exactly.
The set up of the RDS database was case sensitive with respect to table names.